### PR TITLE
Renamed package and linked to Publish runbook

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -145,3 +145,9 @@ Non Open-source Dataset
 -----------------------
 There are tests that run on data that is not open, for more info
 https://kayako.atlassian.net/browse/PDM-8894
+
+
+Publishing Updates
+------------------
+In order to publish new versions of this package, please see this runbook:
+https://trilogy-confluence.atlassian.net/wiki/spaces/KAYAK/pages/935297028/HOWTO+Publish+new+versions+of+kayako-talon+to+PyPI

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,10 +1,10 @@
 [metadata]
-name=ktalon
+name=kayako_talon
 description=Email quoted message striping re-purposed from talon
 version=1.6.0
 author=Mailgun Inc.
 author_email=admin@mailgunhq.com
-url=https://github.com/kayako/ktalon
+url=https://github.com/trilogy-group/kayako-ktalon
 
 [options]
 packages=find:

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,8 @@
 from setuptools import setup, find_packages
 from ConfigParser import ConfigParser
 
-
-# Internal Contact
-# Sherub Thakur <sherub.thakur@kayako.com>
+# In order to publish updates, please check the README,
+# there is a runbook for this.
 
 config = ConfigParser()
 
@@ -23,6 +22,4 @@ setup(
         "nose>=1.2.1",
         "coverage",
     ],
-    setup_requires=["nose>=1.0"]
-)
-
+    setup_requires=["nose>=1.0"])


### PR DESCRIPTION
I renamed the package since the original one's maintainer is gone, and I added a link to a runbook that explains how to publish new versions to PyPI.