### PR TITLE
ghi-3941 | Conversation replies cut-off

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name=kayako_talon
 description=Email quoted message striping re-purposed from talon
-version=1.6.1
+version=1.6.2
 author=Mailgun Inc.
 author_email=admin@mailgunhq.com
 url=https://github.com/trilogy-group/kayako-ktalon

--- a/talon/quotations.py
+++ b/talon/quotations.py
@@ -135,7 +135,7 @@ RE_ORIGINAL_MESSAGE = re.compile(u'[\s]*[-]+[ ]*({})[ ]*[-]+'.format(
         'Oprindelig meddelelse',
     ))), re.I)
 
-RE_FROM_COLON_OR_DATE_COLON = re.compile(u'((_+\r?\n)?[\s]*:?[*]?({})[\s]?:([^\n$]+\n){{1,2}}){{2,}}'.format(
+RE_FROM_COLON_OR_DATE_COLON = re.compile(u'(((_+\r?\n)?[\s]*:?[*]?({})[\s]?:)([^\n$]+\n){{1,2}}){{2,}}'.format(
     u'|'.join((
         # "From" in different languages.
         'From', 'Van', 'De', 'Von', 'Fra', u'Från',


### PR DESCRIPTION
- The regex used to identify headers also trims the content of the email if the content has the same text, like "From:" "To:" etc.