### PR TITLE
Fix case-sensitive configparser import

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 from setuptools import setup, find_packages
-from ConfigParser import ConfigParser
+from configparser import ConfigParser
 
 
 # In order to publish updates, please check the README,


### PR DESCRIPTION
The previous version seems to have only been tested with [`PYTHONCASEOK`](https://docs.python.org/3/using/cmdline.html#envvar-PYTHONCASEOK) set, and would not work on typical systems.